### PR TITLE
Skip annotations for specs that fail after RSpec receives SIGTERM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 
 # rspec failure tracking
 .rspec_status
-.DS_Store

--- a/lib/rspec/buildkite/annotation_formatter.rb
+++ b/lib/rspec/buildkite/annotation_formatter.rb
@@ -27,7 +27,9 @@ module RSpec::Buildkite
     end
 
     def example_failed(notification)
-      @queue.push(notification) if @queue
+      return if @queue.nil? || RSpec.world.wants_to_quit
+
+      @queue.push(notification)
     end
 
     private


### PR DESCRIPTION
There are many scenarios where the RSpec process running on Buildkite is interrupted before completing its spec run (e.g. spot instance termination, build cancellation).

When RSpec is interrupted with SIGTERM it attempts a graceful shutdown during which it treats each in-progress or unstarted spec as a failure, calling each configured formatter.

As a result, every spec that has not yet run is annotated on the build as a failure. This is very confusing since the failures are a result of platform-level concerns and do not actually indicate the success/failure of the individual spec. This is particularly confusing if the build includes actual spec failures since it is not possible to differentiate between specs that actually failed and those that were interrupted. 

This PR makes use of the `RSpec.world.wants_to_quit` global flag to skip annotations for specs that fail after RSpec has received SIGTERM.