### PR TITLE
Submit annotations directly with HTTP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     rspec-buildkite (0.1.4)
+      json
+      net-http
       rspec-core (~> 3.0)
 
 GEM
@@ -13,6 +15,9 @@ GEM
       thor (>= 0.14.0)
     coderay (1.1.2)
     diff-lcs (1.3)
+    json (2.6.3)
+    net-http (0.3.2)
+      uri
     rake (13.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -28,6 +33,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     thor (0.20.3)
+    uri (0.12.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,4 +41,4 @@ DEPENDENCIES
   rspec-buildkite!
 
 BUNDLED WITH
-   1.17.1
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Now run your specs on Buildkite!
 
 ### Docker & Docker Compose
 
-If you run your RSpec builds inside Docker or Docker Compose then you'll need to make sure that buildkite-agent is available inside your container, and that some environment variables are propagated into the running containers. The buildkite-agent binary can be baked into your image, or mounted in as a volume. If you're using [the docker-compose-buildkite-plugin][dcbp] you can pass the environment using [plugin configuration][dcbp-env]. Or you can add them to the [environment section][dc-env] in your `docker-compose.yml`, or supply [env arguments][d-env] to your docker command.
+If you run your RSpec builds inside Docker or Docker Compose then you'll need to make sure that some environment variables are propagated into the running containers. If you're using [the docker-compose-buildkite-plugin][dcbp] you can pass the environment using [plugin configuration][dcbp-env]. Or you can add them to the [environment section][dc-env] in your `docker-compose.yml`, or supply [env arguments][d-env] to your docker command.
 
 The following environment variables are required:
 

--- a/lib/rspec/buildkite/annotation_formatter.rb
+++ b/lib/rspec/buildkite/annotation_formatter.rb
@@ -1,7 +1,10 @@
+require "json"
+require "net/http"
 require "thread"
 
 require "rspec/core"
 require "rspec/buildkite/recolorizer"
+require "rspec/buildkite/version"
 
 module RSpec::Buildkite
   # Create a Buildkite annotation for RSpec failures
@@ -32,17 +35,28 @@ module RSpec::Buildkite
 
     private
 
+    def agent_endpoint
+      ENV.fetch("BUILDKITE_AGENT_ENDPOINT", "https://agent.buildkite.com")
+    end
+
     def thread
       while notification = @queue.pop
         break if notification == :close
 
         if notification
-          system "buildkite-agent", "annotate",
-            "--context", "rspec",
-            "--style", "error",
-            "--append",
-            format_failure(notification),
-            out: :close # only display errors
+          uri = URI.join(agent_endpoint, "v3/jobs/#{ENV.fetch("BUILDKITE_JOB_ID")}/annotations")
+          headers = {
+            "Authorization" => "Token #{ENV.fetch("BUILDKITE_AGENT_ACCESS_TOKEN")}",
+            "User-Agent" => "rspec-buildkite/#{RSpec::Buildkite::VERSION}",
+          }
+          params = {
+            context: "rspec",
+            style: "error",
+            append: true,
+            body: format_failure(notification),
+          }
+
+          Net::HTTP.post(uri, JSON.dump(params), headers).value
         end
       end
     rescue

--- a/rspec-buildkite.gemspec
+++ b/rspec-buildkite.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir["README.md", "LICENSE.txt", "lib/**/*"]
 
-  spec.required_ruby_version = "~> 2.2"
+  spec.required_ruby_version = ">= 2.2", "< 4"
 
   spec.add_dependency "rspec-core", "~> 3.0"
 

--- a/rspec-buildkite.gemspec
+++ b/rspec-buildkite.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2", "< 4"
 
   spec.add_dependency "rspec-core", "~> 3.0"
+  spec.add_dependency "json"
+  spec.add_dependency "net-http"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I'm not sure yet if this is a good idea, but this branch submits annotations directly via HTTP instead of using the `buildkite-agent`. I was struggling to get the `buildkite-agent` binary into a Docker Compose stack, so am trying this out of frustration.

It is potentially breaking -- I had to allow `agent.buildkite.com` in WebMock in my test suite to allow this to work.