### PR TITLE
Use ruby image for pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,5 @@
 steps:
-  - command: bundle exec rake
+  - image: ruby
+    command: bundle exec rake
     env:
       BUNDLE_AUTO_INSTALL: true


### PR DESCRIPTION
This gem has a little test suite which exercises the gem itself - generating some test failures, turning them into an annotation. We should run this in a public pipeline.

The pipeline presumes ruby is installed. We should run it on our "open source" agents, which are hosted agents on linux, and do not have ruby installed. We could reach for the docker plugin, or docker compose plugin, etc .. but what if we just use an off-the-shelf ruby image. So concise! So nice!

(Yes the build is meant to fail!)