### PR TITLE
Remove string literal mutations

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,3 +3,4 @@ steps:
     command: bundle exec rake
     env:
       BUNDLE_AUTO_INSTALL: true
+      RUBYOPT: --enable-frozen-string-literal

--- a/lib/rspec/buildkite.rb
+++ b/lib/rspec/buildkite.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "rspec/buildkite/version"
 require "rspec/buildkite/annotation_formatter"

--- a/lib/rspec/buildkite/annotation_formatter.rb
+++ b/lib/rspec/buildkite/annotation_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 require "rspec/core"
@@ -49,8 +51,8 @@ module RSpec::Buildkite
         end
       end
     rescue
-      $stderr.puts "Warning: Couldn't create Buildkite annotations:\n" <<
-        "  #{$!.to_s}\n" <<
+      $stderr.puts "Warning: Couldn't create Buildkite annotations:\n" +
+        "  #{$!.to_s}\n" +
         "    #{$!.backtrace.join("\n    ")}"
     end
 
@@ -59,19 +61,19 @@ module RSpec::Buildkite
       job_id = ENV["BUILDKITE_JOB_ID"].to_s
       job_url = "#{build_url}##{job_id}"
 
-      %{<details>\n} <<
-      %{<summary>#{notification.description.encode(:xml => :text)}</summary>\n} <<
-      %{<pre class="term">#{Recolorizer.recolorize(notification.colorized_message_lines.join("\n").encode(:xml => :text))}</pre>\n} <<
-      format_rerun(notification) <<
-      %{<p>in <a href=#{job_url.encode(:xml => :attr)}>Job ##{job_id.encode(:xml => :text)}</a></p>\n} <<
-      %{</details>} <<
+      %{<details>\n} +
+      %{<summary>#{notification.description.encode(:xml => :text)}</summary>\n} +
+      %{<pre class="term">#{Recolorizer.recolorize(notification.colorized_message_lines.join("\n").encode(:xml => :text))}</pre>\n} +
+      format_rerun(notification) +
+      %{<p>in <a href=#{job_url.encode(:xml => :attr)}>Job ##{job_id.encode(:xml => :text)}</a></p>\n} +
+      %{</details>} +
       %{\n\n\n}
     end
 
     def format_rerun(notification)
-      %{<pre class="term">} <<
-      %{<span class="term-fg31">rspec #{notification.example.location_rerun_argument.encode(:xml => :text)}</span>} <<
-      %{ <span class="term-fg36"># #{notification.example.full_description.encode(:xml => :text)}</span>} <<
+      %{<pre class="term">} +
+      %{<span class="term-fg31">rspec #{notification.example.location_rerun_argument.encode(:xml => :text)}</span>} +
+      %{ <span class="term-fg36"># #{notification.example.full_description.encode(:xml => :text)}</span>} +
       %{</pre>\n}
     end
   end

--- a/lib/rspec/buildkite/recolorizer.rb
+++ b/lib/rspec/buildkite/recolorizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec::Buildkite
   module Recolorizer
     module_function

--- a/lib/rspec/buildkite/version.rb
+++ b/lib/rspec/buildkite/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Buildkite
     VERSION = "0.1.6"


### PR DESCRIPTION
This removes string literal mutations so that the gem is compatible with `--enable-frozen-string-literal`.

**Changes**

* Replace << with + for string concatenation in `annotation_formatter.rb` to avoid mutating string literals.
* Add ``# frozen_string_literal: true` to all Ruby files for compatibility with frozen string literals.

Fixes #9
