### PR TITLE
fix "can't modify frozen String" errors in recolorize

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-buildkite (0.1.7)
+    rspec-buildkite (0.1.8)
       rspec-core (~> 3.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       thor (>= 0.14.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    rake (13.0.1)
+    rake (13.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -36,7 +36,7 @@ DEPENDENCIES
   appraisal
   bundler (~> 2.3)
   coderay
-  rake
+  rake (>= 13.1)
   rspec (~> 3.0)
   rspec-buildkite!
 

--- a/lib/rspec/buildkite/recolorizer.rb
+++ b/lib/rspec/buildkite/recolorizer.rb
@@ -9,7 +9,7 @@ module RSpec::Buildkite
     def recolorize(string)
       level = 0
       string.gsub(/\e\[(\d+(?:;\d+)*)m/) do
-        "".tap do |buffer|
+        (+"").tap do |buffer|
           codes = $1.split(";").map(&:to_i)
 
           classes = []

--- a/lib/rspec/buildkite/version.rb
+++ b/lib/rspec/buildkite/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module Buildkite
-    VERSION = "0.1.7"
+    VERSION = "0.1.8"
   end
 end

--- a/rspec-buildkite.gemspec
+++ b/rspec-buildkite.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rspec-core", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 2.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 13.1"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "coderay"
   spec.add_development_dependency "appraisal"

--- a/spec/rspec/buildkite/recolorizer_spec.rb
+++ b/spec/rspec/buildkite/recolorizer_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe RSpec::Buildkite::Recolorizer do
+  describe ".recolorize" do
+    it "converts ANSI color codes to HTML spans" do
+      input = "\e[31mred text\e[0m"
+      result = described_class.recolorize(input)
+
+      expect(result).to include('class="term-fg31"')
+      expect(result).to include("red text")
+      expect(result).to include("</span>")
+    end
+
+    it "handles multiple color codes" do
+      input = "\e[1;31mbold red\e[0m"
+      result = described_class.recolorize(input)
+
+      expect(result).to include("term-fg1")
+      expect(result).to include("term-fg31")
+    end
+
+    it "does not raise FrozenError with frozen_string_literal enabled" do
+      # This test verifies the fix for the FrozenError that occurred
+      # when the internal buffer was a frozen empty string literal.
+      # The fix uses (+"") to create a mutable string.
+      input = "\e[32mgreen\e[0m"
+
+      expect { described_class.recolorize(input) }.not_to raise_error
+    end
+
+    it "handles strings without ANSI codes" do
+      input = "plain text"
+      result = described_class.recolorize(input)
+
+      expect(result).to eq("plain text")
+    end
+
+    it "handles 256-color foreground codes" do
+      input = "\e[38;5;196mcolor\e[0m"
+      result = described_class.recolorize(input)
+
+      expect(result).to include("term-fgx196")
+    end
+
+    it "handles 256-color background codes" do
+      input = "\e[48;5;21mcolor\e[0m"
+      result = described_class.recolorize(input)
+
+      expect(result).to include("term-bgx21")
+    end
+  end
+end


### PR DESCRIPTION
Use `+""` to create a mutable string buffer instead of a frozen empty string literal. This prevents "can't modify frozen String" errors when the buffer is appended to with `<<`:

```
Warning: Couldn't create Buildkite annotations:
--
can't modify frozen String: ""
/usr/local/bundle/ruby/3.4.0/gems/rspec-buildkite-0.1.7/lib/rspec/buildkite/recolorizer.rb:49:in 'block (2 levels) in RSpec::Buildkite::Recolorizer.recolorize'
<internal:kernel>:91:in 'Kernel#tap'
/usr/local/bundle/ruby/3.4.0/gems/rspec-buildkite-0.1.7/lib/rspec/buildkite/recolorizer.rb:12:in 'block in RSpec::Buildkite::Recolorizer.recolorize'
/usr/local/bundle/ruby/3.4.0/gems/rspec-buildkite-0.1.7/lib/rspec/buildkite/recolorizer.rb:11:in 'String#gsub'
/usr/local/bundle/ruby/3.4.0/gems/rspec-buildkite-0.1.7/lib/rspec/buildkite/recolorizer.rb:11:in 'RSpec::Buildkite::Recolorizer.recolorize'
/usr/local/bundle/ruby/3.4.0/gems/rspec-buildkite-0.1.7/lib/rspec/buildkite/annotation_formatter.rb:66:in 'RSpec::Buildkite::AnnotationFormatter#format_failure'
/usr/local/bundle/ruby/3.4.0/gems/rspec-buildkite-0.1.7/lib/rspec/buildkite/annotation_formatter.rb:48:in 'RSpec::Buildkite::AnnotationFormatter#thread'
```

Also adds missing specs for `Recolorizer`, written by a coding agent. 

(I also asked the agent to identify any other potential frozen string modification errors, and it did not find any.)